### PR TITLE
Move query to req body instead of uri

### DIFF
--- a/src/client/ClickHouseClient.ts
+++ b/src/client/ClickHouseClient.ts
@@ -140,7 +140,6 @@ export class ClickHouseClient {
         }
 
         const params = new URLSearchParams({
-            query,
             database: this.options.database,
             ...Object.fromEntries(Object.entries(queryParams).map(([key, value]) => [`param_${key}`, value]))
         });
@@ -154,6 +153,7 @@ export class ClickHouseClient {
             params,
             responseType: 'stream',
             method: 'POST',
+            data: query,
             auth: {
                 username: this.options.username,
                 password: this.options.password


### PR DESCRIPTION
Hi

My team and I are using this library, and it's really great.
Yesterday, we stumbled upon a problem with one of our queries.
We have a huge query (Can't paste it here because of our db privacy:)),
and we got an error from our Click house server:

```
<html>
<head><title>414 Request-URI Too Large</title></head>
<body>
<center><h1>414 Request-URI Too Large</h1></center>
</body>
</html>
```

The problem is, that in "_getRequestOptions" the query is forward inside the URI,
and there is a limit of that: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414

So I moved the query to the request body, you can see in the CH documentation that they support the query in the URI and in the body as well: https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters

After that change, the problem solved for us.

Many thanks for your work!
Ilan