### PR TITLE
Client: Return reason from _handlePromiseError so it can be caught

### DIFF
--- a/src/client/ClickHouseClient.ts
+++ b/src/client/ClickHouseClient.ts
@@ -124,8 +124,10 @@ export class ClickHouseClient {
     ) {
         if (reason && reason.response) {
             this.options.logger.error(reason.response.data);
+            return reason.response.data;
         } else {
             this.options.logger.error(reason);
+            return reason;
         }
     }
 


### PR DESCRIPTION
Presently nothing is provided to the .catch chained off client.queryPromise, so no information about the exception can be handled.

Would also appreciate (if this PR is merged) to have nestjs-clickhouse use the updated version of clickhouse-client.  Appreciate all your work on this area!